### PR TITLE
Update PSA rooms now that the server is up

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will find here the default rules for the rooms part of the PSA Community.
 - [Registration](#register)
 
 ### General default rules for PSA rooms **unless specific rules are mentioned below**:<a name="general"></a>
-These are currently only enforced on **#Anonymity:matrix.org**, **#Security:matrix.org**, **#OSINT:matrix.org**, and **#PSA-Offtopic:matrix.org** and not applied on rooms with their own ruleset below.
+These are currently only enforced on **#Anonymity:matrix.anonymousplanet.org**, **#Security:matrix.anonymousplanet.org**, **#OSINT:matrix.anonymousplanet.org**, and **#psa-ot:matrix.anonymousplanet.org** and not applied on rooms with their own ruleset below.
 
 - Keep it legal
 - English only
@@ -66,13 +66,13 @@ See [rules here](https://artemislena.eu/coc.html).
 
 ### Bans:<a name="bans"></a>
 Currently, the following rooms are sharing a common PSA ban list for serious offenders:
-- [#Anonymity](https://matrix.to/#/#anonymity:matrix.org)
-- [#Translations](https://matrix.to/#/#thgtoa-translation:matrix.org)
-- [#Security](https://matrix.to/#/#security:matrix.org)
-- [#Bnonymity](https://matrix.to/#/#bnonymity:matrix.org)
-- [#ModernCrypto](https://matrix.to/#/#moderncrypto:gnuradio.org)
-- [#OSINT](https://matrix.to/#/#OSINT:matrix.org)
-- [#Collab](https://matrix.to/#/#thgtoa-collab:matrix.org)
+- [#Anonymity](https://matrix.to/#/#anonymity:matrix.anonymousplanet.org)
+- [#Translations](https://matrix.to/#/#thgtoa-translation:matrix.anonymousplanet.org)
+- [#Security](https://matrix.to/#/#security:matrix.anonymousplanet.org)
+- [#Bnonymity](https://matrix.to/#/#bnonymity:matrix.anonymousplanet.org)
+- [#ModernCrypto](https://matrix.to/#/#moderncrypto:matrix.anonymousplanet.org)
+- [#OSINT](https://matrix.to/#/#OSINT:matrix.anonymousplanet.org)
+- [#Collab](https://matrix.to/#/#thgtoa-collab:matrix.anonymousplanet.org)
 
 This means that those PSA bans are effectively applied on all those rooms and can be issued by mods of those rooms. See the next section for information about appeals.
 

--- a/_site/CNAME
+++ b/_site/CNAME
@@ -1,0 +1,1 @@
+psa.anonymousplanet.org

--- a/_site/README.md
+++ b/_site/README.md
@@ -6,13 +6,13 @@ You will find here the default rules for the rooms part of the PSA Community.
 
 - [General Rules](#general)
 - [Nothing To Hide Privacy Room Rules](#nth)
-- [Modern Cryprography Room Rules](#moderncrypto)
+- [Modern Cryptography Room Rules](#moderncrypto)
 - [OS Security Room Rules](#ossecurity)
 - [Bnonymity Room Rules](#bnonymity)
 - [Exceptions](#exceptions)
-- [PSA Bans](#psabans)
+- [Bans](#bans)
 - [Ban Appeals](#appeals)
-- [Mods](#mods)
+- [Admins](#admins)
 - [Registration](#register)
 
 ### General default rules for PSA rooms **unless specific rules are mentioned below**:<a name="general"></a>
@@ -24,7 +24,7 @@ These are currently only enforced on **#Anonymity:matrix.org**, **#Security:matr
 - Avoid FUD and/or disinformation
 - Avoid gatekeeping and try to remain welcoming to new users
 - No hate speech (No racism, no homophobia, no transphobia, etc.)
-- No spam
+- No spammerino
 - No doxxing
 - No trolling (this doesn't mean sarcasm is forbidden)
 - No NSFW content (no Porn, no Gore, no Hentai, etc.)
@@ -64,7 +64,7 @@ See [rules here](https://artemislena.eu/coc.html).
 - Talks about Sci-Hub and/or LibGen are allowed
 - Talks about torrenting anonymously are allowed unless the purpose is blatantly illegal
 
-### PSA Bans:<a name="psabans"></a>
+### Bans:<a name="bans"></a>
 Currently, the following rooms are sharing a common PSA ban list for serious offenders:
 - [#Anonymity](https://matrix.to/#/#anonymity:matrix.org)
 - [#Translations](https://matrix.to/#/#thgtoa-translation:matrix.org)
@@ -77,23 +77,11 @@ Currently, the following rooms are sharing a common PSA ban list for serious off
 This means that those PSA bans are effectively applied on all those rooms and can be issued by mods of those rooms. See the next section for information about appeals.
 
 ### Ban Appeals:<a name="appeals"></a>
-Please DM the mods or admins of the room in question on Matrix to state your case for appeal.  
+Please DM the PSA mods or admins of the room in question to state your case for appeal.  
 
-You may also contact us by e-mail at <anonypla@mailfence.com> to state your case.  
-
-You may use our [public PGP key](https://anonymousplanet.org/42FF35DB9DE7C088AB0FD4A70C216A52F6DF4920.asc) to encrypt e-mails. (Do not forget to attach your public key if you want a response). Only use this option if you are unable to contact the mods/admins on Matrix.
-
-### Mods of PSA community (in no particular order):<a name="mods"></a>
-- Babba27: [@memorysafetybelike:envs.net](https://matrix.to/#/@memorysafetybelike:envs.net) / (Root Admin)
-- Dave: [@dave:matrix.anonymousplanet.org](https://matrix.to/#/@dave:matrix.anonymousplanet.org) I'm Sorry Dave (bot)
-- Deejayyhu: [@deejayyhu:matrix.org](https://matrix.to/#/@deejayyhu:matrix.org) (local mod)
-- Rick Deckard: [@2sixty3fifty4:envs.net](https://matrix.to/#/@2sixty3fifty4:envs.net) / [@rick:matrix.anonymousplanet.org](https://matrix.to/#/@rick:matrix.anonymousplanet.org) (Admin)
-- The Hidden: [@thehidden:tchncs.de](https://matrix.to/#/@thehidden:tchncs.de) / [@hidden:matrix.anonymousplanet.org](https://matrix.to/#/@hidden:matrix.anonymousplanet.org) (Admin)
-- <del>Antisec-: [@antisec-:matrix.org](https://matrix.to/#/@antisec-:matrix.org)</del>
-- <del>Fractal: [@fractal:matrix.org](https://matrix.to/#/@fractal:matrix.org)</del>
-- <del>Bob99: [@bob99:tchncs.de](https://matrix.to/#/@bob99:tchncs.de)</del>
-- <del>[michelle](https://matrix.to/#/@michelle:privacytech.xyz)</del> (Admin, currently unavailable)
-- <del>[minji](https://matrix.to/#/@minji:monero.social)</del> (Admin, currently unavailable)
+### Admins:<a name="admins"></a>
+- Babba27: [@memorysafetybelike:envs.net](https://matrix.to/#/@memorysafetybelike:envs.net)
+- No: [@no:matrix.anonymousplanet.org](https://matrix.to/#/@no:matrix.anonymousplanet.org) ([rsa4096/0xB208C4084A2C582D](https://keys.openpgp.org/vks/v1/by-fingerprint/D7939998F78BADB518C1B600B208C4084A2C582D))
 
 ### Registration:<a name="register"></a>
 

--- a/_site/assets/css/style.css
+++ b/_site/assets/css/style.css
@@ -1,6 +1,6 @@
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 /** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap");
+/** @import url("https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap");
 html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
 /** Remove default margin. */

--- a/_site/index.html
+++ b/_site/index.html
@@ -4,38 +4,36 @@
     <meta charset="UTF-8">
 
 <!-- Begin Jekyll SEO tag v2.8.0 -->
-<title>Community Matrix chatroom rules: | Privacy, Security, and Anonymity</title>
+<title>Community Matrix chatroom rules: | Privacy Security Anonymity Community</title>
 <meta name="generator" content="Jekyll v3.9.2" />
 <meta property="og:title" content="Community Matrix chatroom rules:" />
-<meta name="author" content="AnonymousPlanet" />
+<meta name="author" content="Anonymous Planet" />
 <meta property="og:locale" content="en_US" />
-<meta name="description" content="A community project from the Anonymous Planet organization." />
-<meta property="og:description" content="A community project from the Anonymous Planet organization." />
+<meta name="description" content="A Project by the Anonymous Planet Organization" />
+<meta property="og:description" content="A Project by the Anonymous Planet Organization" />
 <link rel="canonical" href="http://localhost:4000/" />
 <meta property="og:url" content="http://localhost:4000/" />
-<meta property="og:site_name" content="Privacy, Security, and Anonymity" />
+<meta property="og:site_name" content="Privacy Security Anonymity Community" />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary" />
 <meta property="twitter:title" content="Community Matrix chatroom rules:" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebSite","author":{"@type":"Person","name":"AnonymousPlanet"},"description":"A community project from the Anonymous Planet organization.","headline":"Community Matrix chatroom rules:","name":"AnonymousPlanet","sameAs":["https://twitter.com/AnonyPla","https://github.com/Anon-Planet","https://matrix.to/#/#privacy-security-anonymity:matrix.org","https://mastodon.social/@anonymousplanet"],"url":"http://localhost:4000/"}</script>
+{"@context":"https://schema.org","@type":"WebSite","author":{"@type":"Person","name":"Anonymous Planet"},"description":"A Project by the Anonymous Planet Organization","headline":"Community Matrix chatroom rules:","name":"Anonymous Planet","sameAs":["https://twitter.com/AnonyPla","https://github.com/Anon-Planet","https://matrix.to/#/#privacy-security-anonymity:matrix.org","https://mastodon.social/@anonymousplanet"],"url":"http://localhost:4000/"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" as="style" type="text/css" crossorigin>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="stylesheet" href="/assets/css/style.css?v=f53d56d293465a150bbd7c51dadac6a376223954">
+    <link rel="stylesheet" href="/assets/css/style.css?v=9be1d13cef8f9ff9fe270aaab423aeeb703e734d">
   </head>
   <body>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">Privacy, Security, and Anonymity</h1>
-      <h2 class="project-tagline">A community project from the Anonymous Planet organization.</h2>
+      <h1 class="project-name">Privacy Security Anonymity Community</h1>
+      <h2 class="project-tagline">A Project by the Anonymous Planet Organization</h2>
       
         <a href="https://github.com/Anon-Planet/PSA" class="btn">View on GitHub</a>
-        <a href="https://anonymousplanet-ng.org" class="btn">The Hitchhiker's Guide</a>
+        <a href="https://anonymousplanet.org" class="btn">The Hitchhiker's Guide To Online Anonymity</a>
       
     </header>
 
@@ -49,13 +47,13 @@
 <ul>
   <li><a href="#general">General Rules</a></li>
   <li><a href="#nth">Nothing To Hide Privacy Room Rules</a></li>
-  <li><a href="#moderncrypto">Modern Cryprography Room Rules</a></li>
+  <li><a href="#moderncrypto">Modern Cryptography Room Rules</a></li>
   <li><a href="#ossecurity">OS Security Room Rules</a></li>
   <li><a href="#bnonymity">Bnonymity Room Rules</a></li>
   <li><a href="#exceptions">Exceptions</a></li>
-  <li><a href="#psabans">PSA Bans</a></li>
+  <li><a href="#bans">Bans</a></li>
   <li><a href="#appeals">Ban Appeals</a></li>
-  <li><a href="#mods">Mods</a></li>
+  <li><a href="#admins">Admins</a></li>
   <li><a href="#register">Registration</a></li>
 </ul>
 
@@ -69,7 +67,7 @@
   <li>Avoid FUD and/or disinformation</li>
   <li>Avoid gatekeeping and try to remain welcoming to new users</li>
   <li>No hate speech (No racism, no homophobia, no transphobia, etc.)</li>
-  <li>No spam</li>
+  <li>No spammerino</li>
   <li>No doxxing</li>
   <li>No trolling (this doesn’t mean sarcasm is forbidden)</li>
   <li>No NSFW content (no Porn, no Gore, no Hentai, etc.)</li>
@@ -116,7 +114,7 @@
   <li>Talks about torrenting anonymously are allowed unless the purpose is blatantly illegal</li>
 </ul>
 
-<h3 id="psa-bans">PSA Bans:<a name="psabans"></a></h3>
+<h3 id="bans">Bans:<a name="bans"></a></h3>
 <p>Currently, the following rooms are sharing a common PSA ban list for serious offenders:</p>
 <ul>
   <li><a href="https://matrix.to/#/#anonymity:matrix.org">#Anonymity</a></li>
@@ -131,24 +129,12 @@
 <p>This means that those PSA bans are effectively applied on all those rooms and can be issued by mods of those rooms. See the next section for information about appeals.</p>
 
 <h3 id="ban-appeals">Ban Appeals:<a name="appeals"></a></h3>
-<p>Please DM the mods or admins of the room in question on Matrix to state your case for appeal.</p>
+<p>Please DM the PSA mods or admins of the room in question to state your case for appeal.</p>
 
-<p>You may also contact us by e-mail at <a href="mailto:anonypla@mailfence.com">anonypla@mailfence.com</a> to state your case.</p>
-
-<p>You may use our <a href="https://anonymousplanet.org/42FF35DB9DE7C088AB0FD4A70C216A52F6DF4920.asc">public PGP key</a> to encrypt e-mails. (Do not forget to attach your public key if you want a response). Only use this option if you are unable to contact the mods/admins on Matrix.</p>
-
-<h3 id="mods-of-psa-community-in-no-particular-order">Mods of PSA community (in no particular order):<a name="mods"></a></h3>
+<h3 id="admins">Admins:<a name="admins"></a></h3>
 <ul>
-  <li>Babba27: <a href="https://matrix.to/#/@memorysafetybelike:envs.net">@memorysafetybelike:envs.net</a> / (Root Admin)</li>
-  <li>Dave: <a href="https://matrix.to/#/@dave:matrix.anonymousplanet.org">@dave:matrix.anonymousplanet.org</a> I’m Sorry Dave (bot)</li>
-  <li>Deejayyhu: <a href="https://matrix.to/#/@deejayyhu:matrix.org">@deejayyhu:matrix.org</a> (local mod)</li>
-  <li>Rick Deckard: <a href="https://matrix.to/#/@2sixty3fifty4:envs.net">@2sixty3fifty4:envs.net</a> / <a href="https://matrix.to/#/@rick:matrix.anonymousplanet.org">@rick:matrix.anonymousplanet.org</a> (Admin)</li>
-  <li>The Hidden: <a href="https://matrix.to/#/@thehidden:tchncs.de">@thehidden:tchncs.de</a> / <a href="https://matrix.to/#/@hidden:matrix.anonymousplanet.org">@hidden:matrix.anonymousplanet.org</a> (Admin)</li>
-  <li><del>Antisec-: <a href="https://matrix.to/#/@antisec-:matrix.org">@antisec-:matrix.org</a></del></li>
-  <li><del>Fractal: <a href="https://matrix.to/#/@fractal:matrix.org">@fractal:matrix.org</a></del></li>
-  <li><del>Bob99: <a href="https://matrix.to/#/@bob99:tchncs.de">@bob99:tchncs.de</a></del></li>
-  <li><del><a href="https://matrix.to/#/@michelle:privacytech.xyz">michelle</a></del> (Admin, currently unavailable)</li>
-  <li><del><a href="https://matrix.to/#/@minji:monero.social">minji</a></del> (Admin, currently unavailable)</li>
+  <li>Babba27: <a href="https://matrix.to/#/@memorysafetybelike:envs.net">@memorysafetybelike:envs.net</a></li>
+  <li>No: <a href="https://matrix.to/#/@no:matrix.anonymousplanet.org">@no:matrix.anonymousplanet.org</a> (<a href="https://keys.openpgp.org/vks/v1/by-fingerprint/D7939998F78BADB518C1B600B208C4084A2C582D">rsa4096/0xB208C4084A2C582D</a>)</li>
 </ul>
 
 <h3 id="registration">Registration:<a name="register"></a></h3>
@@ -160,7 +146,6 @@
         
           <span class="site-footer-owner"><a href="https://github.com/Anon-Planet/PSA">PSA</a> is maintained by <a href="https://github.com/Anon-Planet">Anon-Planet</a>.</span>
         
-        <span class="site-footer-credits">This page was generated by <a href="https://pages.github.com">GitHub Pages</a>.</span>
       </footer>
     </main>
   </body>

--- a/_site/moderncrypto-rules.html
+++ b/_site/moderncrypto-rules.html
@@ -4,47 +4,45 @@
     <meta charset="UTF-8">
 
 <!-- Begin Jekyll SEO tag v2.8.0 -->
-<title>Modern Crypto Rules | Privacy, Security, and Anonymity</title>
+<title>Modern Crypto Rules | Privacy Security Anonymity Community</title>
 <meta name="generator" content="Jekyll v3.9.2" />
 <meta property="og:title" content="Modern Crypto Rules" />
-<meta name="author" content="AnonymousPlanet" />
+<meta name="author" content="Anonymous Planet" />
 <meta property="og:locale" content="en_US" />
-<meta name="description" content="A community project from the Anonymous Planet organization." />
-<meta property="og:description" content="A community project from the Anonymous Planet organization." />
+<meta name="description" content="A Project by the Anonymous Planet Organization" />
+<meta property="og:description" content="A Project by the Anonymous Planet Organization" />
 <link rel="canonical" href="http://localhost:4000/moderncrypto-rules.html" />
 <meta property="og:url" content="http://localhost:4000/moderncrypto-rules.html" />
-<meta property="og:site_name" content="Privacy, Security, and Anonymity" />
+<meta property="og:site_name" content="Privacy Security Anonymity Community" />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary" />
 <meta property="twitter:title" content="Modern Crypto Rules" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebPage","author":{"@type":"Person","name":"AnonymousPlanet"},"description":"A community project from the Anonymous Planet organization.","headline":"Modern Crypto Rules","url":"http://localhost:4000/moderncrypto-rules.html"}</script>
+{"@context":"https://schema.org","@type":"WebPage","author":{"@type":"Person","name":"Anonymous Planet"},"description":"A Project by the Anonymous Planet Organization","headline":"Modern Crypto Rules","url":"http://localhost:4000/moderncrypto-rules.html"}</script>
 <!-- End Jekyll SEO tag -->
 
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700&display=swap" as="style" type="text/css" crossorigin>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#157878">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <link rel="stylesheet" href="/assets/css/style.css?v=f53d56d293465a150bbd7c51dadac6a376223954">
+    <link rel="stylesheet" href="/assets/css/style.css?v=9be1d13cef8f9ff9fe270aaab423aeeb703e734d">
   </head>
   <body>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">Privacy, Security, and Anonymity</h1>
-      <h2 class="project-tagline">A community project from the Anonymous Planet organization.</h2>
+      <h1 class="project-name">Privacy Security Anonymity Community</h1>
+      <h2 class="project-tagline">A Project by the Anonymous Planet Organization</h2>
       
         <a href="https://github.com/Anon-Planet/PSA" class="btn">View on GitHub</a>
-        <a href="https://anonymousplanet-ng.org" class="btn">The Hitchhiker's Guide</a>
+        <a href="https://anonymousplanet.org" class="btn">The Hitchhiker's Guide To Online Anonymity</a>
       
     </header>
 
     <main id="content" class="main-content" role="main">
       <h1 id="modern-crypto-rules">Modern Crypto Rules</h1>
 
-<p>This page documents the rules for my Matrix room, <a href="https://matrix.to/#/#moderncrypto:gnuradio.org">#ModernCrypto</a>.</p>
+<p>This page documents the rules for my Matrix room, <a href="https://matrix.to/#/#moderncrypto:gnuradio.org"><code class="language-plaintext highlighter-rouge">#moderncrypto:gnuradio.org</code></a>.</p>
 
-<p>Modern Crypto is part of the PSA community. See the <a href="index.html">chatroom rules</a>.</p>
+<p>Modern Crypto is part of the PSA community. See <a href="https://anonymousplanet.org/chatrooms-rules.html">https://anonymousplanet.org/chatrooms-rules.html</a></p>
 
 <hr />
 
@@ -72,7 +70,7 @@
   <li>No soliciting donations</li>
   <li>No NSFW content (no Porn, no Gore, no Hentai…)</li>
   <li>No pedophilia</li>
-  <li>Avoid drifting too much off-topic or move to an off-topic room like #bnonymity:matrix.org</li>
+  <li>Avoid drifting too much off-topic or move to an off-topic room like <a href="https://matrix.to/#/#bnonymity:matrix.org"><code class="language-plaintext highlighter-rouge">#bnonymity</code></a></li>
   <li><em>We are not lawyers. Behavior not covered by these rules may be handled at the discretion of any acting moderator(s).</em>
     <ul>
       <li><em>We enforce the spirit of the rules, not the letter.</em></li>
@@ -85,14 +83,18 @@
 
 <hr />
 
-<p>Join the PSA community: Join <a href="https://matrix.to/#/#privacy-security-anonymity:matrix.org">Privacy-Security-Anonymity</a> or <a href="https://matrix.to/#/#p-s-a:matrix.org">P-S-A</a></p>
+<p>Join the PSA community: <a href="https://matrix.to/#/#p-s-a:matrix.org"><code class="language-plaintext highlighter-rouge">#p-s-a:matrix.org</code></a> or <a href="https://matrix.to/#/#privacy-security-anonymity:matrix.org"><code class="language-plaintext highlighter-rouge">#privacy-security-anonymity:matrix.org</code></a></p>
+
+<p>If you want to invite people to Modern Crypto on Discord : https://discord.gg/PTgXQ8ffmw</p>
+
+<p>If you want to invite people to PSA on Discord : https://discord.gg/V8dmd9y7mt</p>
+
 
 
       <footer class="site-footer">
         
           <span class="site-footer-owner"><a href="https://github.com/Anon-Planet/PSA">PSA</a> is maintained by <a href="https://github.com/Anon-Planet">Anon-Planet</a>.</span>
         
-        <span class="site-footer-credits">This page was generated by <a href="https://pages.github.com">GitHub Pages</a>.</span>
       </footer>
     </main>
   </body>

--- a/moderncrypto-rules.md
+++ b/moderncrypto-rules.md
@@ -1,6 +1,6 @@
 # Modern Crypto Rules
 
-This page documents the rules for my Matrix room, [`#moderncrypto:gnuradio.org`](https://matrix.to/#/#moderncrypto:gnuradio.org).
+This page documents the rules for my Matrix room, [`#moderncrypto:gnuradio.org`](https://matrix.to/#/#moderncrypto:matrix.anonymousplanet.org).
 
 Modern Crypto is part of the PSA community. See <https://anonymousplanet.org/chatrooms-rules.html>
 
@@ -23,7 +23,7 @@ Modern Crypto is part of the PSA community. See <https://anonymousplanet.org/cha
 - No soliciting donations
 - No NSFW content (no Porn, no Gore, no Hentai…)
 - No pedophilia
-- Avoid drifting too much off-topic or move to an off-topic room like [`#bnonymity`](https://matrix.to/#/#bnonymity:matrix.org)
+- Avoid drifting too much off-topic or move to an off-topic room like [`#bnonymity`](https://matrix.to/#/#bnonymity:matrix.anonynmousplanet.org)
 - *We are not lawyers. Behavior not covered by these rules may be handled at the discretion of any acting moderator(s).*
   - *We enforce the spirit of the rules, not the letter.*
   - *Citing technicalities or imprecisions in the definitions of rules won't save you.*


### PR DESCRIPTION
The Matrix server is (back) up and operating strongly, so I've updated the PSA space rooms to be native to the server. The previous links will still redirect to the room and there shouldn't be compatibility issues. The space also should not appear broken from the outside now that the base domain is being served at https://matrix.anonymousplanet.org once again.